### PR TITLE
Disable static light once screensaver is on

### DIFF
--- a/script.xbmc.boblight/resources/language/English/strings.xml
+++ b/script.xbmc.boblight/resources/language/English/strings.xml
@@ -40,6 +40,7 @@
   <string id="402">Red</string>
   <string id="403">Green</string>
   <string id="404">Blue</string>
+  <string id="405">Disable when Screen Saver is on</string>
   
   <!--Notifications-->
   <string id="500">Failed to connect to boblightd!</string>

--- a/script.xbmc.boblight/resources/lib/settings.py
+++ b/script.xbmc.boblight/resources/lib/settings.py
@@ -269,12 +269,17 @@ def settings_handleNetworkSettings():
 #category - the category we are in currently
 def settings_handleStaticBgSettings(category):
   global g_staticBobActive
-  other_static_bg     = __settings__.getSetting("other_static_bg") == "true"
-  other_static_red    = int(float(__settings__.getSetting("other_static_red")))
-  other_static_green  = int(float(__settings__.getSetting("other_static_green")))
-  other_static_blue   = int(float(__settings__.getSetting("other_static_blue")))
+  other_static_bg            = __settings__.getSetting("other_static_bg") == "true"
+  other_static_red           = int(float(__settings__.getSetting("other_static_red")))
+  other_static_green         = int(float(__settings__.getSetting("other_static_green")))
+  other_static_blue          = int(float(__settings__.getSetting("other_static_blue")))
+  other_static_onscreensaver = __settings__.getSetting("other_static_onscreensaver") == "true"
   
-  if category == "other" and other_static_bg and not g_bobdisable:#for now enable static light on other if settings want this
+  if (category == "other" and 
+          other_static_bg and 
+          not g_bobdisable and 
+          (not xbmc.getCondVisibility("System.ScreenSaverActive") or not other_static_onscreensaver)
+          ):#for now enable static light on other if settings want this
     bob_set_priority(128)                                  #allow lights to be turned on
     rgb = (c_int * 3)(other_static_red,other_static_green,other_static_blue)
     bob_set_static_color(byref(rgb))

--- a/script.xbmc.boblight/resources/settings.xml
+++ b/script.xbmc.boblight/resources/settings.xml
@@ -40,5 +40,6 @@
     <setting id="other_static_red" type="slider" subsetting="true" enable="eq(-1,true)" label="402" option="int" default="128" range="0,255" />
     <setting id="other_static_green" type="slider" subsetting="true" enable="eq(-2,true)" label="403" option="int" default="128" range="0,255" />
     <setting id="other_static_blue" type="slider" subsetting="true" enable="eq(-3,true)" label="404" option="int" default="128" range="0,255" />
+    <setting id="other_static_onscreensaver" type="bool" label="405" default="false" />
   </category>
 </settings>


### PR DESCRIPTION
I found that I like the static light on, but if I switch the TV off light still stays on as XBMC is always on.

this will disable static light when the screensaver kicks in (configurable in addon setting, default to off)

Cheers,
amet
