### PR TITLE
Fix detection of 'livetv' mode.

### DIFF
--- a/script.xbmc.boblight/default.py
+++ b/script.xbmc.boblight/default.py
@@ -162,8 +162,6 @@ def myPlayerChanged(state):
         ret = "musicvideo"
       elif xbmc.getCondVisibility("VideoPlayer.Content(episodes)"):
         ret = "tvshow"
-      elif xbmc.getCondVisibility("VideoPlayer.Content(livetv)"):
-        ret = "livetv"
       elif xbmc.getCondVisibility("VideoPlayer.Content(files)"):
         ret = "files"
 
@@ -180,6 +178,9 @@ def myPlayerChanged(state):
         elif settings.overwrite_cat_val == 4:
           ret = "files"
 
+    # Player.HasVideo() returns False for "livetv".
+    elif xbmc.getCondVisibility("VideoPlayer.Content(livetv)"):
+      ret = "livetv"
     elif xbmc.getCondVisibility("Player.HasAudio()"):
       ret = "static"
     else:


### PR DESCRIPTION
Fixed detection of "livetv". Player.HasVideo() does return False  when watching Live TV.
