### PR TITLE
Black Bar Detection

### DIFF
--- a/script.xbmc.boblight/README
+++ b/script.xbmc.boblight/README
@@ -5,6 +5,8 @@ For accessing the settings during video playback just put the file script.xbmc.b
 You can access the settings during playback by hitting the key "b" or "B". (Note: a former keymapping to that key will be overwritten by this keymap file. If there is a 
 conflict you just can change the mapped key to something else).
 
+Black Bar Detection searches for black areas in letterboxed/pillarboxed material and removes them. The vertical scan is performed in the top lines of the screen until a non black pixel is found or the maximum vertical scan area is reached. For each line only a centered range is scanned. With this option scans can be accelerated and also unwanted parts of the screens, e.g. with TV-logos, can be hidden. The analogue scan is performed from the left side. A threshold for black pixels could be defined. For optimizing performance and result the captured frame size and interval for scanning could be set. Capture dimensions relating to your led dimensions may be a good choice.
+
 For this addon to be working you need a library for communicating with the boblightd - daemon. You can download it here:
 
 Windows:

--- a/script.xbmc.boblight/default.py
+++ b/script.xbmc.boblight/default.py
@@ -204,9 +204,9 @@ def run_boblight():
   player_monitor.playing = xbmc.Player().isPlaying()
   if main.startup() == 0:
     capture        = xbmc.RenderCapture()
-    capture.capture(capture_width, capture_height, xbmc.CAPTURE_FLAG_CONTINUOUS)
+    capture.capture(settings.frame_capture_width, settings.frame_capture_height, xbmc.CAPTURE_FLAG_CONTINUOUS)
     while not xbmc.abortRequested:
-      xbmc.sleep(100)
+      xbmc.sleep(settings.frame_capture_interval)
       if not settings.bobdisable:
         if not bob.bob_ping() or settings.reconnect:
           if not main.connectBoblight():
@@ -214,22 +214,47 @@ def run_boblight():
           if settings.bob_init():
             check_state()
           settings.reconnect = False
-          
+
         if not settings.staticBobActive:
           capture.waitForCaptureStateChangeEvent(1000)
           if capture.getCaptureState() == xbmc.CAPTURE_STATE_DONE and player_monitor.isPlaying():
             width = capture.getWidth();
+            if width == 0:
+              return
             height = capture.getHeight();
             pixels = capture.getImage();
-            bob.bob_setscanrange(width, height)
+            pxl_width = width * 4
+            range_x_min = int(width / 2 * (1 - settings.scan_range)) * 4
+            range_x_max = int(width / 2 * (1 + settings.scan_range)) * 4
+            range_y_min = int(height / 2 * (1 - settings.scan_range)) * pxl_width
+            range_y_max = int(height / 2 * (1 + settings.scan_range)) * pxl_width
+            found = False
+            for yc in range(0, int(height * settings.scan_v) * pxl_width, pxl_width):
+              for xi in range (range_x_min + yc, range_x_max + yc, 4):
+                if pixels[xi] > settings.scan_threshold or pixels[xi + 1] > settings.scan_threshold or pixels[xi + 2] > settings.scan_threshold:
+                  found = True
+                  break
+              if found:
+                break
+            yc = int(yc / pxl_width)
+            found = False
+            for xc in range(0, int(width * settings.scan_h) * 4, 4):
+              for yi in range (range_y_min + xc, range_y_max + xc , pxl_width):
+                if pixels[yi] > settings.scan_threshold or pixels[yi + 1] > settings.scan_threshold or pixels[yi + 2] > settings.scan_threshold:
+                  found = True
+                  break
+              if found:
+                break
+            xc = int(xc / 4)
+            bob.bob_setscanrange(width - xc * 2, height - yc * 2)
             rgb = (c_int * 3)()
-            for y in range(height):
-              row = width * y * 4
-              for x in range(width):
-                rgb[0] = pixels[row + x * 4 + 2]
-                rgb[1] = pixels[row + x * 4 + 1]
-                rgb[2] = pixels[row + x * 4]
-                bob.bob_addpixelxy(x, y, byref(rgb))
+            for y in range(yc, height - yc):
+              for x in range(xc, width - xc):
+                pxl = (y * width + x) * 4
+                rgb[0] = pixels[pxl + 2]
+                rgb[1] = pixels[pxl + 1]
+                rgb[2] = pixels[pxl]
+                bob.bob_addpixelxy(x - xc, y - yc, byref(rgb))
 
             bob.bob_set_priority(128)
             if not bob.bob_sendrgb():

--- a/script.xbmc.boblight/resources/language/English/strings.po
+++ b/script.xbmc.boblight/resources/language/English/strings.po
@@ -87,6 +87,34 @@ msgctxt "#32207"
 msgid "Threshold"
 msgstr ""
 
+msgctxt "#32208"
+msgid "Black Bars H-Size"
+msgstr ""
+
+msgctxt "#32209"
+msgid "Black Bars V-Size"
+msgstr ""
+
+msgctxt "#32210"
+msgid "Black Bars Threshold"
+msgstr ""
+
+msgctxt "#32211"
+msgid "Black Bars Scan Range"
+msgstr ""
+
+msgctxt "#32212"
+msgid "Frame Capture Interval"
+msgstr ""
+
+msgctxt "#32213"
+msgid "Frame Capture Width"
+msgstr ""
+
+msgctxt "#32214"
+msgid "Frame Capture Height"
+msgstr ""
+
 #empty strings from id 32208 to 32219
 
 msgctxt "#32220"

--- a/script.xbmc.boblight/resources/lib/settings.py
+++ b/script.xbmc.boblight/resources/lib/settings.py
@@ -146,10 +146,10 @@ class settings():
     self.music_interpolation        = int(__addon__.getSetting("musicvideo_interpolation") == "true")
     self.music_threshold            = float(__addon__.getSetting("musicvideo_threshold"))
     self.music_preset               = int(__addon__.getSetting("musicvideo_preset"))
-    self.music_scan_v               = float(__addon__.getSetting("music_scan_v"))
-    self.music_scan_h               = float(__addon__.getSetting("music_scan_h"))
-    self.music_scan_threshold       = int(float(__addon__.getSetting("music_scan_threshold")))
-    self.music_scan_range           = float(__addon__.getSetting("music_scan_range"))
+    self.music_scan_v               = float(__addon__.getSetting("musicvideo_scan_v"))
+    self.music_scan_h               = float(__addon__.getSetting("musicvideo_scan_h"))
+    self.music_scan_threshold       = int(float(__addon__.getSetting("musicvideo_scan_threshold")))
+    self.music_scan_range           = float(__addon__.getSetting("musicvideo_scan_range"))
 
   def resetBobDisable(self):
     # reset the bobdisable setting from settings

--- a/script.xbmc.boblight/resources/lib/settings.py
+++ b/script.xbmc.boblight/resources/lib/settings.py
@@ -73,6 +73,10 @@ class settings():
         self.hostip   = hostip
         self.hostport = hostport        
         self.reconnect = True
+
+    self.frame_capture_interval        = int(float(__addon__.getSetting("frame_capture_interval")))
+    self.frame_capture_width           = int(float(__addon__.getSetting("frame_capture_width")))
+    self.frame_capture_height          = int(float(__addon__.getSetting("frame_capture_height")))
     
     # Other settings
     self.other_static_bg            = __addon__.getSetting("other_static_bg") == "true"
@@ -90,6 +94,10 @@ class settings():
     self.movie_interpolation        = int(__addon__.getSetting("movie_interpolation") == "true")
     self.movie_threshold            = float(__addon__.getSetting("movie_threshold"))
     self.movie_preset               = int(__addon__.getSetting("movie_preset"))
+    self.movie_scan_v               = float(__addon__.getSetting("movie_scan_v"))
+    self.movie_scan_h               = float(__addon__.getSetting("movie_scan_h"))
+    self.movie_scan_threshold       = int(float(__addon__.getSetting("movie_scan_threshold")))
+    self.movie_scan_range           = float(__addon__.getSetting("movie_scan_range"))
 
     # TV Shows settings
     self.tvshow_saturation           = float(__addon__.getSetting("tvshow_saturation"))
@@ -99,7 +107,11 @@ class settings():
     self.tvshow_interpolation        = int(__addon__.getSetting("tvshow_interpolation") == "true")
     self.tvshow_threshold            = float(__addon__.getSetting("tvshow_threshold"))
     self.tvshow_preset               = int(__addon__.getSetting("tvshow_preset"))
-
+    self.tvshow_scan_v               = float(__addon__.getSetting("tvshow_scan_v"))
+    self.tvshow_scan_h               = float(__addon__.getSetting("tvshow_scan_h"))
+    self.tvshow_scan_threshold       = int(float(__addon__.getSetting("tvshow_scan_threshold")))
+    self.tvshow_scan_range           = float(__addon__.getSetting("tvshow_scan_range"))
+    
     # LiveTV settings
     self.livetv_saturation           = float(__addon__.getSetting("livetv_saturation"))
     self.livetv_value                = float(__addon__.getSetting("livetv_value"))
@@ -108,7 +120,11 @@ class settings():
     self.livetv_interpolation        = int(__addon__.getSetting("livetv_interpolation") == "true")
     self.livetv_threshold            = float(__addon__.getSetting("livetv_threshold"))
     self.livetv_preset               = int(__addon__.getSetting("livetv_preset"))
-
+    self.livetv_scan_v               = float(__addon__.getSetting("livetv_scan_v"))
+    self.livetv_scan_h               = float(__addon__.getSetting("livetv_scan_h"))
+    self.livetv_scan_threshold       = int(float(__addon__.getSetting("livetv_scan_threshold")))
+    self.livetv_scan_range           = float(__addon__.getSetting("livetv_scan_range"))
+    
     # Files settings
     self.files_saturation           = float(__addon__.getSetting("files_saturation"))
     self.files_value                = float(__addon__.getSetting("files_value"))
@@ -117,7 +133,11 @@ class settings():
     self.files_interpolation        = int(__addon__.getSetting("files_interpolation") == "true")
     self.files_threshold            = float(__addon__.getSetting("files_threshold"))
     self.files_preset               = int(__addon__.getSetting("files_preset"))
-      
+    self.files_scan_v               = float(__addon__.getSetting("files_scan_v"))
+    self.files_scan_h               = float(__addon__.getSetting("files_scan_h"))
+    self.files_scan_threshold       = int(float(__addon__.getSetting("files_scan_threshold")))
+    self.files_scan_range           = float(__addon__.getSetting("files_scan_range"))
+         
     # Music Video settings
     self.music_saturation           = float(__addon__.getSetting("musicvideo_saturation"))
     self.music_value                = float(__addon__.getSetting("musicvideo_value"))
@@ -126,6 +146,10 @@ class settings():
     self.music_interpolation        = int(__addon__.getSetting("musicvideo_interpolation") == "true")
     self.music_threshold            = float(__addon__.getSetting("musicvideo_threshold"))
     self.music_preset               = int(__addon__.getSetting("musicvideo_preset"))
+    self.music_scan_v               = float(__addon__.getSetting("music_scan_v"))
+    self.music_scan_h               = float(__addon__.getSetting("music_scan_h"))
+    self.music_scan_threshold       = int(float(__addon__.getSetting("music_scan_threshold")))
+    self.music_scan_range           = float(__addon__.getSetting("music_scan_range"))
 
   def resetBobDisable(self):
     # reset the bobdisable setting from settings
@@ -155,6 +179,10 @@ class settings():
       autospeed     = 0.0 
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.movie_preset == 2:     #preset action
       saturation    = 3.0
       value         = 10.0
@@ -162,6 +190,10 @@ class settings():
       autospeed     = 0.0  
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.movie_preset == 3:     #preset disabled
       saturation    = 0.0
       value         = 0.0
@@ -169,6 +201,10 @@ class settings():
       autospeed     = 0.0  
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.movie_preset == 0:     #custom
       saturation      =  self.movie_saturation
       value           =  self.movie_value
@@ -176,6 +212,10 @@ class settings():
       autospeed       =  self.movie_autospeed
       interpolation   =  self.movie_interpolation
       threshold       =  self.movie_threshold
+      self.scan_v          =  self.movie_scan_v
+      self.scan_h          =  self.movie_scan_h
+      self.scan_threshold  =  self.movie_scan_threshold
+      self.scan_range      =  self.movie_scan_range
     return (saturation,value,speed,autospeed,interpolation,threshold)
 
   #handle boblight configuration from the "TVShows" category
@@ -190,6 +230,10 @@ class settings():
       autospeed     = 0.0 
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.tvshow_preset == 2:     #preset action
       saturation    = 3.0
       value         = 10.0
@@ -197,6 +241,10 @@ class settings():
       autospeed     = 0.0  
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.tvshow_preset == 3:     #preset disabled
       saturation    = 0.0
       value         = 0.0
@@ -204,6 +252,10 @@ class settings():
       autospeed     = 0.0  
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.tvshow_preset == 0:     #custom
       saturation      =  self.tvshow_saturation
       value           =  self.tvshow_value
@@ -211,6 +263,10 @@ class settings():
       autospeed       =  self.tvshow_autospeed
       interpolation   =  self.tvshow_interpolation
       threshold       =  self.tvshow_threshold
+      self.scan_v          =  self.tvshow_scan_v
+      self.scan_h          =  self.tvshow_scan_h
+      self.scan_threshold  =  self.tvshow_scan_threshold
+      self.scan_range      =  self.tvshow_scan_range
     return (saturation,value,speed,autospeed,interpolation,threshold)
 
   #handle boblight configuration from the "LiveTV" category
@@ -225,6 +281,10 @@ class settings():
       autospeed     = 0.0 
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.livetv_preset == 2:     #preset action 
       saturation    = 3.0
       value         = 10.0
@@ -232,6 +292,10 @@ class settings():
       autospeed     = 0.0  
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.livetv_preset == 3:     #preset disabled
       saturation    = 0.0
       value         = 0.0
@@ -239,6 +303,10 @@ class settings():
       autospeed     = 0.0  
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.livetv_preset == 0:     #custom
       saturation      =  self.livetv_saturation
       value           =  self.livetv_value
@@ -246,6 +314,10 @@ class settings():
       autospeed       =  self.livetv_autospeed
       interpolation   =  self.livetv_interpolation
       threshold       =  self.livetv_threshold
+      self.scan_v          =  self.livetv_scan_v
+      self.scan_h          =  self.livetv_scan_h
+      self.scan_threshold  =  self.livetv_scan_threshold
+      self.scan_range      =  self.livetv_scan_range
     return (saturation,value,speed,autospeed,interpolation,threshold)
 
   #handle boblight configuration from the "files" category
@@ -260,6 +332,10 @@ class settings():
       autospeed     = 0.0 
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.files_preset == 2:     #preset action
       saturation    = 3.0
       value         = 10.0
@@ -267,6 +343,10 @@ class settings():
       autospeed     = 0.0  
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.files_preset == 3:     #preset disabled
       saturation    = 0.0
       value         = 0.0
@@ -274,6 +354,10 @@ class settings():
       autospeed     = 0.0  
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.files_preset == 0:     #custom
       saturation      =  self.files_saturation
       value           =  self.files_value
@@ -281,6 +365,10 @@ class settings():
       autospeed       =  self.files_autospeed
       interpolation   =  self.files_interpolation
       threshold       =  self.files_threshold
+      self.scan_v          =  self.files_scan_v
+      self.scan_h          =  self.files_scan_h
+      self.scan_threshold  =  self.files_scan_threshold
+      self.scan_range      =  self.files_scan_range
     return (saturation,value,speed,autospeed,interpolation,threshold)
     
   #handle boblight configuration from the "MusicVideo" category
@@ -295,6 +383,10 @@ class settings():
       autospeed     = 0.0
       interpolation = 1
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.music_preset == 2:     #preset Rock
       saturation    = 3.0
       value         = 10.0
@@ -302,6 +394,10 @@ class settings():
       autospeed     = 0.0  
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.music_preset == 3:     #preset disabled
       saturation    = 0.0
       value         = 0.0
@@ -309,6 +405,10 @@ class settings():
       autospeed     = 0.0  
       interpolation = 0
       threshold     = 0.0
+      self.scan_v          =  0.0
+      self.scan_h          =  0.0
+      self.scan_threshold  =  0
+      self.scan_range      =  0.0
     elif self.music_preset == 0:     #custom
       saturation      =  self.music_saturation
       value           =  self.music_value
@@ -316,6 +416,10 @@ class settings():
       autospeed       =  self.music_autospeed
       interpolation   =  self.music_interpolation
       threshold       =  self.music_threshold    
+      self.scan_v          =  self.music_scan_v
+      self.scan_h          =  self.music_scan_h
+      self.scan_threshold  =  self.music_scan_threshold
+      self.scan_range      =  self.music_scan_range
     return (saturation,value,speed,autospeed,interpolation,threshold)
   
   #handle boblight configuration from the "other" category
@@ -329,6 +433,10 @@ class settings():
   #  autospeed       =  float(__addon__.getSetting("other_autospeed"))
   #  interpolation   =  __addon__.getSetting("other_interpolation") == "true"
   #  threshold       =  float(__addon__.getSetting("other_threshold"))
+    self.scan_v          =  0.0
+    self.scan_h          =  0.0
+    self.scan_threshold  =  0
+    self.scan_range      =  0.0
     return self.setupForStatic()
   
   #handle boblight configuration for static lights
@@ -341,6 +449,10 @@ class settings():
     autospeed     = 0.0 
     interpolation = 1
     threshold     = 0.0
+    self.scan_v          =  0.0
+    self.scan_h          =  0.0
+    self.scan_threshold  =  0
+    self.scan_range      =  0.0
     return (saturation,value,speed,autospeed,interpolation,threshold)
 
   #handle all settings according to the static bg light

--- a/script.xbmc.boblight/resources/settings.xml
+++ b/script.xbmc.boblight/resources/settings.xml
@@ -7,6 +7,9 @@
     <setting id="networkaccess" type="bool" label="32101" default="false" />
     <setting id="hostip" type="ipaddress" subsetting="true" enable="eq(-1,true)" label="32102" default="127.0.0.1" />
     <setting id="hostport" type="number" subsetting="true" enable="eq(-2,true)" label="32103" default="19333" />
+    <setting id="frame_capture_interval" type="slider" label="32212" option="int" default="100" range="0,500" />
+    <setting id="frame_capture_width" type="slider" label="32213" option="int" default="64" range="1,256" />
+    <setting id="frame_capture_height" type="slider" label="32214" option="int" default="64" range="1,256" />
     <setting id="sep2" type="sep" />
     <setting id="bobdisableonscreensaver" type="bool" label="32405" default="false" />
     <setting id="bobdisableon3d" type="bool" label="32107" default="false" />
@@ -14,39 +17,54 @@
   </category>
   <category label="32200">
     <setting id="movie_preset" type="enum" label="32201" default="1" lvalues="32220|32221|32222|32223" />
-    <setting id="movie_speed" type="slider" subsetting="true" visible="eq(-1,0)" label="32202" default="100" range="0,100" />
+    <setting id="movie_speed" type="slider" subsetting="true" visible="eq(-1,0)" label="32202" default="30" range="0,100" />
     <setting id="movie_autospeed" type="slider" subsetting="true" visible="eq(-2,0)" label="32203" default="0" range="0,100" />
     <setting id="movie_interpolation" type="bool" subsetting="true" visible="eq(-3,0)" label="32204" default="false" />
-    <setting id="movie_saturation" type="slider" subsetting="true" visible="eq(-4,0)" label="32205" option="float" default="0" range="0,0.1,20" />
-    <setting id="movie_value" type="slider" subsetting="true" visible="eq(-5,0)" label="32206" option="float" default="0" range="0,0.1,20" />
+    <setting id="movie_saturation" type="slider" subsetting="true" visible="eq(-4,0)" label="32205" option="float" default="1.0" range="0,0.1,20" />
+    <setting id="movie_value" type="slider" subsetting="true" visible="eq(-5,0)" label="32206" option="float" default="1.0" range="0,0.1,20" />
     <setting id="movie_threshold" type="slider" subsetting="true" visible="eq(-6,0)" label="32207" default="0" range="0,255" />
+    <setting id="movie_scan_h" type="slider" subsetting="true" visible="eq(-7,0)" label="32208" default="0.15" range="0,0.01,1" />
+    <setting id="movie_scan_v" type="slider" subsetting="true" visible="eq(-8,0)" label="32209" default="0.15" range="0,0.01,1" />
+    <setting id="movie_scan_threshold" type="slider" subsetting="true" visible="eq(-9,0)" label="32210" option="int" default="10" range="0,255" />
+    <setting id="movie_scan_range" type="slider" subsetting="true" visible="eq(-10,0)" label="32211" default="0.33" range="0,0.01,1" />
   </category>
   <category label="32600">
     <setting id="tvshow_preset" type="enum" label="32201" default="1" lvalues="32620|32621|32622|32623" />
     <setting id="tvshow_speed" type="slider" subsetting="true" visible="eq(-1,0)" label="32202" default="100" range="0,100" />
     <setting id="tvshow_autospeed" type="slider" subsetting="true" visible="eq(-2,0)" label="32203" default="0" range="0,100" />
     <setting id="tvshow_interpolation" type="bool" subsetting="true" visible="eq(-3,0)" label="32204" default="false" />
-    <setting id="tvshow_saturation" type="slider" subsetting="true" visible="eq(-4,0)" label="32205" option="float" default="0" range="0,0.1,20" />
-    <setting id="tvshow_value" type="slider" subsetting="true" visible="eq(-5,0)" label="32206" option="float" default="0" range="0,0.1,20" />
+    <setting id="tvshow_saturation" type="slider" subsetting="true" visible="eq(-4,0)" label="32205" option="float" default="1.0" range="0,0.1,20" />
+    <setting id="tvshow_value" type="slider" subsetting="true" visible="eq(-5,0)" label="32206" option="float" default="1.0" range="0,0.1,20" />
     <setting id="tvshow_threshold" type="slider" subsetting="true" visible="eq(-6,0)" label="32207" default="0" range="0,255" />
-  </category>
+    <setting id="tvshow_scan_h" type="slider" subsetting="true" visible="eq(-7,0)" label="32208" default="0.15" range="0,0.01,1" />
+    <setting id="tvshow_scan_v" type="slider" subsetting="true" visible="eq(-8,0)" label="32209" default="0.15" range="0,0.01,1" />
+    <setting id="tvshow_scan_threshold" type="slider" subsetting="true" visible="eq(-9,0)" label="32210" option="int" default="10" range="0,255" />
+    <setting id="tvshow_scan_range" type="slider" subsetting="true" visible="eq(-10,0)" label="32211" default="0.33" range="0,0.01,1" /> </category>
   <category label="32700">
     <setting id="livetv_preset" type="enum" label="32201" default="1" lvalues="32720|32721|32722|32723" />
     <setting id="livetv_speed" type="slider" subsetting="true" visible="eq(-1,0)" label="32202" default="100" range="0,100" />
     <setting id="livetv_autospeed" type="slider" subsetting="true" visible="eq(-2,0)" label="32203" default="0" range="0,100" />
     <setting id="livetv_interpolation" type="bool" subsetting="true" visible="eq(-3,0)" label="32204" default="false" />
-    <setting id="livetv_saturation" type="slider" subsetting="true" visible="eq(-4,0)" label="32205" option="float" default="0" range="0,0.1,20" />
-    <setting id="livetv_value" type="slider" subsetting="true" visible="eq(-5,0)" label="32206" option="float" default="0" range="0,0.1,20" />
+    <setting id="livetv_saturation" type="slider" subsetting="true" visible="eq(-4,0)" label="32205" option="float" default="1.0" range="0,0.1,20" />
+    <setting id="livetv_value" type="slider" subsetting="true" visible="eq(-5,0)" label="32206" option="float" default="1.0" range="0,0.1,20" />
     <setting id="livetv_threshold" type="slider" subsetting="true" visible="eq(-6,0)" label="32207" default="0" range="0,255" />
+    <setting id="livetv_scan_h" type="slider" subsetting="true" visible="eq(-7,0)" label="32208" default="0.15" range="0,0.01,1" />
+    <setting id="livetv_scan_v" type="slider" subsetting="true" visible="eq(-8,0)" label="32209" default="0.15" range="0,0.01,1" />
+    <setting id="livetv_scan_threshold" type="slider" subsetting="true" visible="eq(-9,0)" label="32210" option="int" default="10" range="0,255" />
+    <setting id="livetv_scan_range" type="slider" subsetting="true" visible="eq(-10,0)" label="32211" default="0.33" range="0,0.01,1" />  
   </category>
   <category label="32300">
     <setting id="musicvideo_preset" type="enum" label="32201" default="1" lvalues="32320|32321|32322|32323" />
     <setting id="musicvideo_speed" type="slider" subsetting="true" visible="eq(-1,0)" label="32202" default="100" range="0,100" />
     <setting id="musicvideo_autospeed" type="slider" subsetting="true" visible="eq(-2,0)" label="32203" default="0" range="0,100" />
     <setting id="musicvideo_interpolation" type="bool" subsetting="true" visible="eq(-3,0)" label="32204" default="false" />
-    <setting id="musicvideo_saturation" type="slider" subsetting="true" visible="eq(-4,0)" label="32205" option="float" default="1" range="0,0.1,20" />
-    <setting id="musicvideo_value" type="slider" subsetting="true" visible="eq(-5,0)" label="32206" option="float" default="1" range="0,0.1,20" />
+    <setting id="musicvideo_saturation" type="slider" subsetting="true" visible="eq(-4,0)" label="32205" option="float" default="1.0" range="0,0.1,20" />
+    <setting id="musicvideo_value" type="slider" subsetting="true" visible="eq(-5,0)" label="32206" option="float" default="1.0" range="0,0.1,20" />
     <setting id="musicvideo_threshold" type="slider" subsetting="true" visible="eq(-6,0)" label="32207" default="0" range="0,255" />
+    <setting id="musicvideo_scan_h" type="slider" subsetting="true" visible="eq(-7,0)" label="32208" default="0.15" range="0,0.01,1" />
+    <setting id="musicvideo_scan_v" type="slider" subsetting="true" visible="eq(-8,0)" label="32209" default="0.15" range="0,0.01,1" />
+    <setting id="musicvideo_scan_threshold" type="slider" subsetting="true" visible="eq(-9,0)" label="32210" option="int" default="10" range="0,255" />
+    <setting id="musicvideo_scan_range" type="slider" subsetting="true" visible="eq(-10,0)" label="32211" default="0.33" range="0,0.01,1" />
   </category>
   <category label="32800">
     <setting id="files_preset" type="enum" label="32201" default="1" lvalues="32820|32821|32822|32823" />
@@ -56,6 +74,10 @@
     <setting id="files_saturation" type="slider" subsetting="true" visible="eq(-4,0)" label="32205" option="float" default="0" range="0,0.1,20" />
     <setting id="files_value" type="slider" subsetting="true" visible="eq(-5,0)" label="32206" option="float" default="0" range="0,0.1,20" />
     <setting id="files_threshold" type="slider" subsetting="true" visible="eq(-6,0)" label="32207" default="0" range="0,255" />
+    <setting id="files_scan_h" type="slider" subsetting="true" visible="eq(-7,0)" label="32208" default="0.15" range="0,0.01,1" />
+    <setting id="files_scan_v" type="slider" subsetting="true" visible="eq(-8,0)" label="32209" default="0.15" range="0,0.01,1" />
+    <setting id="files_scan_threshold" type="slider" subsetting="true" visible="eq(-9,0)" label="32210" option="int" default="10" range="0,255" />
+    <setting id="files_scan_range" type="slider" subsetting="true" visible="eq(-10,0)" label="32211" default="0.33" range="0,0.01,1" />
   </category>
   <category label="32400">
 <!-- uncomment these settings when boblight works on menu and non rendered stuff too
@@ -64,7 +86,11 @@
     <setting id="other_interpolation" type="bool" label="32204" default="false" />
     <setting id="other_saturation" type="slider" label="32205" default="1" option="float" range="0,0.1,20" />
     <setting id="other_value" type="slider" label="32206" default="1" option="float" range="0,0.1,20" />
-    <setting id="other_threshold" type="slider" label="32207" default="0" range="0,255" />-->
+    <setting id="other_threshold" type="slider" label="32207" default="0" range="0,255" 
+    <setting id="other_scan_h" type="slider" label="32208" default="0.15" range="0,0.01,1" />
+    <setting id="other_scan_v" type="slider" label="32209" default="0.15" range="0,0.01,1" />
+    <setting id="other_scan_threshold" type="slider" label="32210" option="int" default="10" range="0,255" />
+    <setting id="other_scan_range" type="slider" label="32211" default="0.33" range="0,0.01,1" />-->
     <setting id="other_static_bg" type="bool" label="32401" default="false" />
     <setting id="other_static_red" type="slider" subsetting="true" enable="eq(-1,true)" label="32402" option="int" default="128" range="0,255" />
     <setting id="other_static_green" type="slider" subsetting="true" enable="eq(-2,true)" label="32403" option="int" default="128" range="0,255" />


### PR DESCRIPTION
Hello,

I added a Black Bar Detection. With this feature usual workarounds, like large boblight scan areas, e.g. 20%, are not necessary anymore. Now also small scan areas, e.g. 6%, work fine and give a much more natural detailed view.

The code is optimized for speed (e.g. taking all reoccurring calculations outside the scan loops, using the address format 4 bytes / pixels in the counters) in order to make this feasible also on low cpu powered machines. By removing the black bars the following copy to boblight is faster. So overall there should be no real difference in cpu usage for real world examples (e.g. 2.35 movie on 16:9 screen), even with switched on black bar detection. I didn't include a on/off switch, if the black bar scan area is set to 0 then the loops will immediately terminate and the capture will be copied to boblight without any cuts. 

I put some descriptions into the README to explain the parameters:

> Black Bar Detection searches for black areas in letterboxed/pillarboxed material and removes them.  The vertical scan is performed in the top lines of the screen until a non black pixel is found or the maximum vertical scan area is reached. For each line only a centered range is scanned. With this option scans can be accelerated and also unwanted parts of the screens, e.g. with TV-logos, can be hidden. The analogue scan is performed from the left side. A threshold for black pixels could be defined. For optimizing performance and result the captured frame size and interval for scanning could be set. Capture dimensions relating to your led dimensions may be a good choice.

I hope you like this additional code and it will find its way into the official boblight plug-in.

Best regards,
Steve