### PR TITLE
Also return android platform for aarch64

### DIFF
--- a/script.xbmc.boblight/resources/lib/tools.py
+++ b/script.xbmc.boblight/resources/lib/tools.py
@@ -77,7 +77,7 @@ def get_platform():
   elif  xbmc.getCondVisibility('system.platform.tvos'):
     platform = "tvos"
   elif  xbmc.getCondVisibility('system.platform.android'):
-    if os.uname()[4].startswith("arm"):
+    if os.uname()[4].startswith("arm") or os.uname()[4].startswith("aarch64"):
       platform = "android"
     else:
       platform = "androidx86"


### PR DESCRIPTION
This fixes the incorrect platform and dependency download on the nvidia shield and probably even some more android boxes.