### PR TITLE
add setting to choose max video resolution allowed for boblight

### DIFF
--- a/script.xbmc.boblight/default.py
+++ b/script.xbmc.boblight/default.py
@@ -198,8 +198,13 @@ def myPlayerChanged(state):
     else:
       ret = "movie"
 
+  if ret == "static":
+    videores = "static"
+  else:
+    videores = xbmc.getInfoLabel("VideoPlayer.VideoResolution")
+
   settings.handleCategory(ret)
-  settings.handleStereoscopic(xbmc.getInfoLabel("System.StereoscopicMode") != "0")
+  settings.handleStart(xbmc.getInfoLabel("System.StereoscopicMode") != "0", videores)
 
 def run_boblight():
   main = Main()

--- a/script.xbmc.boblight/resources/language/English/strings.po
+++ b/script.xbmc.boblight/resources/language/English/strings.po
@@ -52,7 +52,11 @@ msgctxt "#32107"
 msgid "Disable for 3D content"
 msgstr ""
 
-#empty strings from id 32108 to 32199
+msgctxt "#32108"
+msgid "Maximum resolution allowed"
+msgstr ""
+
+#empty strings from id 32109 to 32199
 #Movie/MusicVideo/Other
 
 msgctxt "#32200"

--- a/script.xbmc.boblight/resources/lib/settings.py
+++ b/script.xbmc.boblight/resources/lib/settings.py
@@ -60,6 +60,7 @@ class settings():
     self.bobdisableonscreensaver    = __addon__.getSetting("bobdisableonscreensaver") == "true"
     self.bobdisable                 = __addon__.getSetting("bobdisable") == "true"
     self.bobdisableon3d             = __addon__.getSetting("bobdisableon3d") == "true"
+    self.bobmaxres                  = __addon__.getSetting("bobmaxres")
     self.current_option             = ""
     
     if not self.networkaccess:
@@ -392,13 +393,22 @@ class settings():
     self.handleGlobalSettings()
     self.handleStaticBgSettings()
 
-  def handleStereoscopic(self, isStereoscopic):
-    log('settings() - handleStereoscopic(%s) - disableon3d (%s)' % (isStereoscopic, self.bobdisableon3d))
+  def handleStart(self, isStereoscopic, resolution):
+    log('settings() - handleStart(%s, %s) - disableon3d (%s) - maxres (%s)' % (isStereoscopic, resolution, self.bobdisableon3d, self.bobmaxres))
     if self.bobdisableon3d and isStereoscopic:
       log('settings()- disable due to 3d')
       self.bobdisable = True
+    elif self.bobmaxres and self.getNumRes(resolution) > self.bobmaxres:
+      log('settings()- disable due to denied resolution')
+      self.bobdisable = True
     else:
       self.resetBobDisable()
+
+  def getNumRes(self, resolution):
+    mapping = [ ('static', '0'), ('480', '1'), ('576', '2'), ('540', '3'), ('720', '4'), ('1080', '5'), ('4K', '6'), ('8K', '7') ]
+    for k, v in mapping:
+      resolution = resolution.replace(k, v)
+    return resolution
 
   def bob_init(self):
     if self.run_init:

--- a/script.xbmc.boblight/resources/settings.xml
+++ b/script.xbmc.boblight/resources/settings.xml
@@ -10,6 +10,7 @@
     <setting id="sep2" type="sep" />
     <setting id="bobdisableonscreensaver" type="bool" label="32405" default="false" />
     <setting id="bobdisableon3d" type="bool" label="32107" default="false" />
+    <setting id="bobmaxres" type="enum" label="32108" default="0" values="Any|480p|576p|540p|720p|1080p|4K|8K" />
     <setting id="bobdisable" type="bool" label="32104" default="false" />
   </category>
   <category label="32200">


### PR DESCRIPTION
I find that my fairly recent HTPC struggles to handle boblight when playing something in 4K, but it's OK in 1080p, so I added this option to choose which maximum resolution you want boblight to run with when playing videos.

Tested and working on my setup.